### PR TITLE
Fix environment variable assignment

### DIFF
--- a/clive.service
+++ b/clive.service
@@ -9,7 +9,7 @@ Group=nobody
 Environment=PATH=/usr/bin:/usr/local/bin
 Environment=NODE_ENV=production
 Environment=DISCORD_WEBHOOK_URL=https://discordapp.com/api/webhooks/YOUR_DISCORD/WEBHOOK_URL_HERE
-Environment=TWITCH_CHANNELS="a_twitch_channel another_twitch_channel"
+Environment="TWITCH_CHANNELS=a_twitch_channel another_twitch_channel"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Quotes need to wrap the variable to work with spaces. Before, variables where breaking on the space and being imported with a literal `"`