### PR TITLE
Add delay to discord post

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,12 +58,12 @@ client.on("message", function (channel, userstate, message, self) {
 // Connect the client to the server..
 client.connect();
 
-function postDiscordMessage(val) {
+function postDiscordMessage(msg) {
   request.post(
     DISCORD_WEBHOOK_URL,
     { json:
       {
-        content: val,
+        content: msg,
         username: "Clive",
         avatar_url: "http://i.imgur.com/9s3TBNv.png",
       }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ client.on("message", function (channel, userstate, message, self) {
 	// Delay the message to ensure its finished being genreated by Twitch
         setTimeout(
           postDiscordMessage(`**@${userstate["display-name"]}** posted a clip: ${message}`),
-	  DISCORD_POST_DELAY);
+	  DISCORD_POST_DELAY
+	);
       }
       break;
     case "whisper":

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const _ = require('lodash');
 
 const DISCORD_WEBHOOK_URL = _.get(process, 'env.DISCORD_WEBHOOK_URL') || "YOUR_DISCORD_WEBHOOK_URL_HERE";
+const DISCORD_POST_DELAY = _.get(process, 'env.DISCORD_POST_DELAY') || 30 * 1000; // 30s
 let channelArray = _.get(process, 'env.TWITCH_CHANNELS');
+
 if (channelArray) {
 	channelArray = _.split(channelArray, ' ');
 } else {
@@ -38,7 +40,10 @@ client.on("message", function (channel, userstate, message, self) {
     case "chat":
       // console.log(userstate);
       if (message.indexOf("clips.twitch.tv/") !== -1) {
-        postThing(`**${userstate["display-name"]}** posted a clip: ${message}`);
+	// Delay the message to ensure its finished being genreated by Twitch
+        setTimeout(
+          postDiscordMessage(`**@${userstate["display-name"]}** posted a clip: ${message}`),
+	  DISCORD_POST_DELAY);
       }
       break;
     case "whisper":
@@ -53,7 +58,7 @@ client.on("message", function (channel, userstate, message, self) {
 // Connect the client to the server..
 client.connect();
 
-function postThing(val) {
+function postDiscordMessage(val) {
   request.post(
     DISCORD_WEBHOOK_URL,
     { json:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
 const DISCORD_WEBHOOK_URL = _.get(process, 'env.DISCORD_WEBHOOK_URL') || "YOUR_DISCORD_WEBHOOK_URL_HERE";
-const DISCORD_POST_DELAY = _.get(process, 'env.DISCORD_POST_DELAY') || 30 * 1000; // 30s
+const DISCORD_POST_DELAY = _.get(process, 'env.DISCORD_POST_DELAY') || 1000; // 1s
 let channelArray = _.get(process, 'env.TWITCH_CHANNELS');
 
 if (channelArray) {
@@ -42,7 +42,7 @@ client.on("message", function (channel, userstate, message, self) {
       if (message.indexOf("clips.twitch.tv/") !== -1) {
 	// Delay the message to ensure its finished being genreated by Twitch
         setTimeout(
-          postDiscordMessage(`**@${userstate["display-name"]}** posted a clip: ${message}`),
+          () => postDiscordMessage(`**@${userstate["display-name"]}** posted a clip: ${message}`),
 	  DISCORD_POST_DELAY
 	);
       }


### PR DESCRIPTION
Users will often post the URL to a clip immediately into twitch chat before it's done being generated which causes it to not have a video player in Discord.
I've added a delay to give twitch time to finish generating the clip before posting it into Discord.